### PR TITLE
Version 61.6.0 Coverage Rate Now support on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,9 @@ endif()
 target_sources(${PROJECT_NAME} PUBLIC
     ${HEADERS}
     ${QM_FILES}
-    ${README_FILES})
+    ${README_FILES}
+    ./covagelnk
+)
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${SRV_HEADER_PATH})
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/TestCase/CMakeLists.txt
+++ b/TestCase/CMakeLists.txt
@@ -29,7 +29,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test Core Gui Sql Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test Core Gui Sql Widgets)
 
-
 file(GLOB SOURCES
     # service module sources
     ../Actions/*.cpp
@@ -168,3 +167,8 @@ target_compile_definitions(${PROJECT_NAME}
     $<$<CONFIG:Debug>:QT_MESSAGELOGCONTEXT>
 )
 message("[${PROJECT_NAME}] Finished...")
+
+if(UNIX AND NOT APPLE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
+endif()

--- a/covagelnk
+++ b/covagelnk
@@ -1,0 +1,1 @@
+/home/ariel/code/FileXplorer/build/FileXplorerTest_Desktop_Qt_5_15_2_GCC_64bit-Debug/coverage_report/index.html


### PR DESCRIPTION
<img width="1789" height="601" alt="image" src="https://github.com/user-attachments/assets/d7a5bd44-08e3-4568-86b9-6a832b0f345f" />

<img width="1171" height="406" alt="Version 61 5 9 all 75 TestCase Pass" src="https://github.com/user-attachments/assets/d087c160-aa1e-4389-94ac-b4cbcc7716a4" />

